### PR TITLE
test-image-peregeneration

### DIFF
--- a/api/pollinations_api.py
+++ b/api/pollinations_api.py
@@ -66,19 +66,21 @@ class PollinationsAPI:
         encoded_prompt = urllib.parse.quote(prompt)
         url = f"{self.base_url}/prompt/{encoded_prompt}"
         
-        attempt = 1
-        buttons_activated = False
-        retry_delay = 10 # Фіксована затримка
+        retry_delay = 10 
+        
+        # Кількість спроб тепер береться з налаштувань, а не з константи
+        # Головна логіка перемикання буде в combain.py, тут ми просто робимо N спроб
+        max_retries = self.app.config.get("pollinations", {}).get("retries", 5)
 
-        while True: # БЕЗКІНЕЧНИЙ ЦИКЛ СПРОБ
+        for attempt in range(1, max_retries + 1):
             try:
                 # Перевірка на пропуск користувачем на початку кожної ітерації
                 if self.app.skip_image_event.is_set():
                     logger.warning("Pollinations -> Генерацію ОДНОГО зображення пропущено користувачем.")
-                    self.app.skip_image_event.clear() # Очищаємо прапорець одразу
-                    return False # Повертаємо False, щоб перейти до наступного зображення
+                    self.app.skip_image_event.clear()
+                    return False
 
-                logger.info(f"Pollinations -> Генерація зображення (спроба #{attempt})...")
+                logger.info(f"Pollinations -> Генерація зображення (спроба #{attempt}/{max_retries})...")
                 
                 response = requests.get(url, params=params, timeout=180)
                 
@@ -86,30 +88,21 @@ class PollinationsAPI:
                     with open(output_path, 'wb') as f:
                         f.write(response.content)
                     logger.info(f"Pollinations -> УСПІХ: Зображення збережено в {output_path}")
-                    return True # Успіх, виходимо з циклу та функції
+                    return True
                 else:
-                    logger.warning(f"Pollinations -> Спроба #{attempt} не вдалася. Статус: {response.status_code}. Повтор через {retry_delay}с...")
+                    logger.warning(f"Pollinations -> Спроба #{attempt} не вдалася. Статус: {response.status_code}.")
             
             except requests.exceptions.RequestException as e:
-                logger.error(f"Pollinations -> ПОМИЛКА: Запит не вдався (спроба #{attempt}): {e}. Повтор через {retry_delay}с...")
+                logger.error(f"Pollinations -> ПОМИЛКА: Запит не вдався (спроба #{attempt}): {e}.")
 
-            # Логіка активації кнопок після 5 невдалих спроб
-            if attempt >= 5 and not buttons_activated:
-                logger.error(f"Pollinations -> 5 невдалих спроб. Активація кнопки пропуску та відправка сповіщення в Telegram.")
-                self.app._update_button_states(is_processing=True, is_image_stuck=True)
-                self.app.tg_api.send_message_with_buttons(
-                    message="❌ *Помилка генерації зображення*\n\nНе вдається згенерувати зображення після 5 спроб\\. Процес очікує\\. Оберіть дію:",
-                    buttons=[
-                        {"text": "Пропустити ЦЕ зображення", "callback_data": "skip_image_action"},
-                        {"text": "Перемкнути сервіс", "callback_data": "switch_service_action"}
-                    ]
-                )
-                buttons_activated = True
+            # Якщо це не остання спроба, чекаємо перед повтором
+            if attempt < max_retries:
+                logger.info(f"Повторна спроба через {retry_delay}с...")
+                if self.app.skip_image_event.wait(timeout=retry_delay):
+                    logger.warning("Pollinations -> Генерацію пропущено користувачем під час очікування.")
+                    self.app.skip_image_event.clear()
+                    return False
 
-            # Очікування перед наступною спробою (може бути перерване командою пропуску)
-            if self.app.skip_image_event.wait(timeout=retry_delay):
-                logger.warning("Pollinations -> Генерацію ОДНОГО зображення пропущено користувачем під час очікування.")
-                self.app.skip_image_event.clear() # Очищаємо прапорець тут також
-                return False # Повертаємо False, щоб перейти до наступного зображення
-
-            attempt += 1
+        # Якщо всі спроби провалилися
+        logger.error(f"Pollinations -> Не вдалося згенерувати зображення після {max_retries} спроб.")
+        return False

--- a/api/telegram_api.py
+++ b/api/telegram_api.py
@@ -114,10 +114,12 @@ class TelegramAPI:
             logger.error(f"Telegram -> Помилка мережі при отриманні оновлень: {e}")
             return None
 
-    def answer_callback_query(self, callback_query_id):
+    def answer_callback_query(self, callback_query_id, text=None):
         """Відповідає на натискання кнопки, щоб прибрати годинник."""
         url = f"{self.base_url}/answerCallbackQuery"
         payload = {'callback_query_id': callback_query_id}
+        if text:
+            payload['text'] = text
         try:
             requests.post(url, json=payload, timeout=5)
         except requests.exceptions.RequestException as e:

--- a/constants/default_config.py
+++ b/constants/default_config.py
@@ -24,7 +24,6 @@ DEFAULT_CONFIG = {
         "width": 1920,
         "height": 1080,
         "timeout": 6,
-        "retries": 5,
         "remove_logo": True
     },
     "recraft": {
@@ -141,6 +140,8 @@ DEFAULT_CONFIG = {
             "time": 150,
             "status": 100
         },
-        "image_control_enabled": False
+        "image_control_enabled": False,
+        "auto_switch_service_on_fail": False,
+        "auto_switch_retry_limit": 10
     }
 }

--- a/gui/log_tab.py
+++ b/gui/log_tab.py
@@ -46,6 +46,30 @@ def create_log_tab(notebook, app):
     switch_service_button_log.pack(side='left', padx=5)
     app.switch_service_buttons.append(switch_service_button_log)
 
+    # --- Нова кнопка регенерації іншим сервісом ---
+    regenerate_alt_button_log = ttk.Button(
+        log_buttons_frame,
+        text=app._t('regenerate_alt_button'),
+        command=app._on_regenerate_alt_click,
+        bootstyle="success",
+        state="disabled"
+    )
+    regenerate_alt_button_log.pack(side='left', padx=5)
+    app.regenerate_alt_buttons.append(regenerate_alt_button_log)
+
+    # --- Новий вибір API ---
+    ttk.Label(log_buttons_frame, text=f"{app._t('image_api_label')}:").pack(side='left', padx=(10, 2))
+    image_api_combo_log = ttk.Combobox(
+        log_buttons_frame, 
+        textvariable=app.active_image_api_var, 
+        values=["pollinations", "recraft"], 
+        state="readonly",
+        width=12
+    )
+    image_api_combo_log.pack(side='left', padx=5)
+    image_api_combo_log.bind("<<ComboboxSelected>>", app._on_image_api_select)
+    app.image_api_selectors.append(image_api_combo_log)
+
     parallel_container_frame = ttk.Labelframe(app.log_frame, text=app._t('parallel_log_label'))
     parallel_container_frame.pack(fill='both', expand=True, padx=5, pady=(2, 5))
 

--- a/gui/rewrite_tab.py
+++ b/gui/rewrite_tab.py
@@ -136,6 +136,30 @@ def create_rewrite_tab(notebook, app):
     switch_service_button_rewrite.pack(side='left', padx=5)
     app.switch_service_buttons.append(switch_service_button_rewrite)
 
+    # --- Нова кнопка регенерації іншим сервісом ---
+    regenerate_alt_button_rewrite = ttk.Button(
+        rewrite_buttons_frame,
+        text=app._t('regenerate_alt_button'),
+        command=app._on_regenerate_alt_click,
+        bootstyle="success",
+        state="disabled"
+    )
+    regenerate_alt_button_rewrite.pack(side='left', padx=5)
+    app.regenerate_alt_buttons.append(regenerate_alt_button_rewrite)
+
+    # --- Новий вибір API ---
+    ttk.Label(rewrite_buttons_frame, text=f"{app._t('image_api_label')}:").pack(side='left', padx=(10, 2))
+    image_api_combo_rewrite = ttk.Combobox(
+        rewrite_buttons_frame, 
+        textvariable=app.active_image_api_var, 
+        values=["pollinations", "recraft"], 
+        state="readonly",
+        width=12
+    )
+    image_api_combo_rewrite.pack(side='left', padx=5)
+    image_api_combo_rewrite.bind("<<ComboboxSelected>>", app._on_image_api_select)
+    app.image_api_selectors.append(image_api_combo_rewrite)
+
     queue_main_frame = ttk.Labelframe(app.rewrite_scrollable_frame, text=app._t('task_queue_tab'))
     queue_main_frame.pack(fill='x', expand=True, padx=10, pady=10)
 

--- a/gui/settings_tab.py
+++ b/gui/settings_tab.py
@@ -175,13 +175,7 @@ def create_api_settings_subtabs(parent_tab, app):
     poll_timeout_spinbox = ttk.Spinbox(poll_frame, from_=1, to=30, textvariable=app.poll_timeout_var, width=10)
     poll_timeout_spinbox.grid(row=4, column=1, sticky='w', padx=5, pady=5)
     add_text_widget_bindings(app, poll_timeout_spinbox)
-    
-    ttk.Label(poll_frame, text=app._t('retries_label')).grid(row=5, column=0, sticky='w', padx=5, pady=5)
-    app.poll_retries_var = tk.IntVar(value=app.config["pollinations"]["retries"])
-    poll_retries_spinbox = ttk.Spinbox(poll_frame, from_=1, to=10, textvariable=app.poll_retries_var, width=10)
-    poll_retries_spinbox.grid(row=5, column=1, sticky='w', padx=5, pady=5)
-    add_text_widget_bindings(app, poll_retries_spinbox)
-    
+
     app.poll_remove_logo_var = tk.BooleanVar(value=app.config["pollinations"]["remove_logo"])
     ttk.Checkbutton(poll_frame, variable=app.poll_remove_logo_var, text=app._t('remove_logo_label'), bootstyle="light-round-toggle").grid(row=6, column=0, sticky='w', padx=5, pady=5)
 
@@ -615,20 +609,27 @@ def create_other_settings_tab(parent_tab, app):
     add_text_widget_bindings(app, theme_combo)
     theme_combo.bind("<<ComboboxSelected>>", app.on_theme_changed)
     
-    theme_map_to_display = {
-        "darkly": app._t('theme_darkly'), 
-        "cyborg": app._t('theme_cyborg'), 
-        "litera": app._t('theme_litera')
-    }
+    theme_combo['values'] = list(app.theme_map_to_display.values())
+    
+    # Встановлюємо відображуване значення
     current_theme_key = app.config.get("ui_settings", {}).get("theme", "darkly")
-    app.theme_var.set(theme_map_to_display.get(current_theme_key, app._t('theme_darkly')))
+    display_value = app.theme_map_to_display.get(current_theme_key, app._t('theme_darkly'))
+    app.theme_var.set(display_value)
 
-    ttk.Label(general_frame, text=app._t('image_api_label')).grid(row=2, column=0, sticky='w', padx=5, pady=5)
-    app.image_api_var = tk.StringVar(value=app.config.get("ui_settings", {}).get("image_generation_api", "pollinations"))
-    image_api_combo = ttk.Combobox(general_frame, textvariable=app.image_api_var, values=["pollinations", "recraft"], state="readonly")
-    image_api_combo.grid(row=2, column=1, sticky='ew', padx=5, pady=5)
     app.image_control_var = tk.BooleanVar(value=app.config.get("ui_settings", {}).get("image_control_enabled", False))
     ttk.Checkbutton(general_frame, variable=app.image_control_var, text=app._t('image_control_label')).grid(row=3, column=0, columnspan=2, sticky='w', padx=5, pady=5)
+
+    # --- Нові налаштування авто-перемикання ---
+    auto_switch_frame = ttk.Frame(general_frame)
+    auto_switch_frame.grid(row=4, column=0, columnspan=3, sticky='w', padx=5, pady=5)
+
+    app.auto_switch_var = tk.BooleanVar(value=app.config.get("ui_settings", {}).get("auto_switch_service_on_fail", False))
+    ttk.Checkbutton(auto_switch_frame, variable=app.auto_switch_var, text=app._t('auto_switch_service_label')).pack(side='left', anchor='w')
+    
+    ttk.Label(auto_switch_frame, text=app._t('retry_limit_label')).pack(side='left', padx=(10, 2))
+    app.auto_switch_retries_var = tk.IntVar(value=app.config.get("ui_settings", {}).get("auto_switch_retry_limit", 10))
+    ttk.Spinbox(auto_switch_frame, from_=1, to=50, textvariable=app.auto_switch_retries_var, width=5).pack(side='left')
+
 
     output_cfg = app.config.get('output_settings', DEFAULT_CONFIG['output_settings'])
     output_frame = ttk.Labelframe(scrollable_frame, text=app._t('output_settings_label'))

--- a/gui/task_tab.py
+++ b/gui/task_tab.py
@@ -192,6 +192,30 @@ def create_task_tab(notebook, app):
     )
     switch_service_button_chain.pack(side='left', padx=5)
     app.switch_service_buttons.append(switch_service_button_chain)
+
+    # --- Нова кнопка регенерації іншим сервісом ---
+    regenerate_alt_button_chain = ttk.Button(
+        chain_buttons_frame,
+        text=app._t('regenerate_alt_button'),
+        command=app._on_regenerate_alt_click,
+        bootstyle="success",
+        state="disabled"
+    )
+    regenerate_alt_button_chain.pack(side='left', padx=5)
+    app.regenerate_alt_buttons.append(regenerate_alt_button_chain)
+
+    # --- Новий вибір API ---
+    ttk.Label(chain_buttons_frame, text=f"{app._t('image_api_label')}:").pack(side='left', padx=(10, 2))
+    image_api_combo_chain = ttk.Combobox(
+        chain_buttons_frame, 
+        textvariable=app.active_image_api_var, 
+        values=["pollinations", "recraft"], 
+        state="readonly",
+        width=12
+    )
+    image_api_combo_chain.pack(side='left', padx=5)
+    image_api_combo_chain.bind("<<ComboboxSelected>>", app._on_image_api_select)
+    app.image_api_selectors.append(image_api_combo_chain)
     
     queue_main_frame = ttk.Labelframe(app.chain_scrollable_frame, text=app._t('task_queue_tab'))
     queue_main_frame.pack(fill='x', expand=True, padx=10, pady=10)

--- a/translations.json
+++ b/translations.json
@@ -291,7 +291,10 @@
         "speechify_rate_label": "Швидкість:",
         "report_timing_label": "Режим звіту:",
         "report_timing_per_task": "Після всього завдання",
-        "report_timing_per_language": "Після кожної мови"
+        "report_timing_per_language": "Після кожної мови",
+        "auto_switch_service_label": "Авто-перемикання сервісу при помилці",
+        "retry_limit_label": "Спроб до перемикання:",
+        "regenerate_alt_button": "Спробувати іншим сервісом"
     },
     "en": {
         "api_tab_label": "API",
@@ -583,6 +586,9 @@
         "speechify_rate_label": "Rate:",
         "report_timing_label": "Report Mode:",
         "report_timing_per_task": "After the entire task",
-        "report_timing_per_language": "After each language"
+        "report_timing_per_language": "After each language",
+        "auto_switch_service_label": "Auto-switch service on failure",
+        "retry_limit_label": "Retries before switch:",
+        "regenerate_alt_button": "Try with another service"
     }
 }


### PR DESCRIPTION
Нова функція: Автоматичне перемикання сервісу зображень
    * У налаштування ("Інше" -> "Загальні") додано опцію "Авто-перемикання сервісу при помилці" та лічильник спроб.
    * Якщо функція увімкнена, програма автоматично перемкне сервіс (напр. з Pollinations на Recraft) після вказаної кількості невдалих спроб згенерувати одне зображення.
    * Після перемикання програма спробує повторно згенерувати проблемне зображення і продовжить роботу з новим сервісом до кінця черги.

Рефакторинг інтерфейсу та налаштувань
    * Прибрано зайве налаштування: Видалено поле "Спроби" з налаштувань Pollinations, оскільки нова функція робить його непотрібним.
    * Перенесено вибір API: Випадаючий список для вибору сервісу генерації зображень (Pollinations/Recraft) перенесено з налаштувань безпосередньо на робочі вкладки "Створення Завдання", "Рерайт" та "Лог" для зручності.

Внутрішні покращення
    * Централізовано логіку повторних спроб та перемикання сервісів у головному файлі `combain.py` для кращої стабільності.
    * Виправлено помилку, пов'язану зі збереженням та відображенням теми інтерфейсу.

Оновлено логіку кнопок керування зображеннями:
    * "Пропустити зображення" тепер пропускає лише одне поточне зображення, а не всю мову.
    * "Перемкнути сервіс" тепер перемикає сервіс для всіх наступних зображень до самого кінця черги.

Додано нову кнопку "Спробувати іншим сервісом":
    * Ця кнопка з'являється разом з іншими, коли виникає проблема з генерацією.
    * Вона робить *одну спробу* згенерувати проблемне зображення альтернативним сервісом.
    * Після цієї спроби програма *повертається до сервісу за замовчуванням* для наступних зображень.
    * Кнопка також додана до сповіщень у Telegram.

Покращення інтерфейсу:
    * Усі три кнопки керування тепер згруповані разом на вкладках "Створення Завдання", "Рерайт" та "Лог" для зручного доступу.